### PR TITLE
Fixed edge case where other provider adds user before mp_auth does

### DIFF
--- a/mp_auth/backends/globus.py
+++ b/mp_auth/backends/globus.py
@@ -99,14 +99,17 @@ class GlobusAuthentication(MultiproviderBaseAuthentication):
             user_association = UserAssociation.objects.get(provider=provider, uid=sub)
             user = user_association.user
         except UserAssociation.DoesNotExist:
-            fullname, firstname, lastname = self.get_user_names(name)
-            user = UserModel.objects.create(
-                    first_name=firstname,
-                    last_name=lastname,
-                    email=email,
-                    username=username,
-            )
-            logger.debug("New user '{}' created".format(user.username))
+            try:
+                user = UserModel.objects.get(username=username)
+            except UserModel.DoesNotExist:
+                fullname, firstname, lastname = self.get_user_names(name)
+                user = UserModel.objects.create(
+                        first_name=firstname,
+                        last_name=lastname,
+                        email=email,
+                        username=username,
+                )
+                logger.debug("New user '{}' created".format(user.username))
             user_association = UserAssociation.objects.create(
                     user=user, uid=sub, provider=provider)
             AccessToken.objects.create(


### PR DESCRIPTION
If another provider is present on the system (such as the resource
server acting as a portal in addition to being a resource server),
it's possible for the user to already exist. This adds a check to
make sure we reuse the user if the username matches (usernames
must be unique in django).